### PR TITLE
(Raid-Ulduar) Hodir Flash Freeze safe spots

### DIFF
--- a/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
+++ b/src/server/scripts/Northrend/Ulduar/Ulduar/boss_hodir.cpp
@@ -423,7 +423,7 @@ public:
                             targets.push_back(itr->GetSource());
                         targets.remove_if(acore::ObjectTypeIdCheck(TYPEID_PLAYER, false));
                         targets.remove_if(acore::UnitAuraCheck(true, SPELL_FLASH_FREEZE_TRAPPED_PLAYER));
-                        acore::Containers::RandomResizeList(targets, 2);
+                        acore::Containers::RandomResizeList(targets, (RAID_MODE(2,3)));
                         for (std::list<Unit*>::const_iterator itr = targets.begin(); itr != targets.end(); ++itr)
                         {
                             float prevZ = (*itr)->GetPositionZ();


### PR DESCRIPTION
## CHANGES PROPOSED:
Hodir now creates 2 safe spots for Flash Freeze in 10-man and 3 safe spots in 25-man.

## ISSUES ADDRESSED:
#3556

## HOW TO TEST THE CHANGES:
Enter 10-man Ulduar with 3 characters.
.go xyz 2000.61 -245.43 432.69 603
Hodir should create 2 safe spots for flash freeze.

Enter 25-man Ulduar with 3 characters.
Hodir should create 3 safe spots for flash freeze.


## How to test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here in the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR
